### PR TITLE
Support for c style hex notation as string

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,28 @@
 ![Category overview screenshot](docs/images/oainet.png "Microsoft + OpenAPI = Love")
 
-# OpenAPI.NET 
+# APIM
+## OpenApi
+Forked from: https://github.com/microsoft/OpenAPI.NET
 
+Based on 1.2.3 553061a69b2d8b8b1653f172707409a16f2a9579
+
+Changes:
+- Data type mismatch validation disabled for example, examples, enum, default, e.t.c.
+- OpenApiDate does not serialize time
+- (v1.2.4-apim6) added c-style hex notation string support to serialize as a string
+  - '0x1234' will serialize to '0x1234' instead of 0x1234
+
+## OpenApiReader
+Forked from: https://github.com/microsoft/OpenAPI.NET
+
+Based on 1.2.3 553061a69b2d8b8b1653f172707409a16f2a9579
+
+Changes:
+- OpenApiYamlDocumentReader class made public
+- Reading "dddd-dd-dd" as OpenApiDate, rather than OpenApiDateTime, unless schema is specified
+
+
+# OpenAPI.NET 
 |Package|Nuget|
 |--|--|
 |Models and Writers|[![nuget](https://img.shields.io/nuget/v/Microsoft.OpenApi.svg)](https://www.nuget.org/packages/Microsoft.OpenApi/) |

--- a/src/Microsoft.OpenApi.Readers/Microsoft.OpenApi.Readers.csproj
+++ b/src/Microsoft.OpenApi.Readers/Microsoft.OpenApi.Readers.csproj
@@ -10,7 +10,7 @@
         <Company>Microsoft</Company>
         <Title>Microsoft.OpenApi.Readers</Title>
         <PackageId>Microsoft.ApiManagement.OpenApi.Readers</PackageId>
-        <Version>1.2.4-apim5</Version>
+        <Version>1.2.4-apim6</Version>
         <Description>OpenAPI.NET Readers for JSON and YAML documents</Description>
         <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
         <PackageTags>OpenAPI .NET</PackageTags>

--- a/src/Microsoft.OpenApi/Microsoft.OpenApi.csproj
+++ b/src/Microsoft.OpenApi/Microsoft.OpenApi.csproj
@@ -10,7 +10,7 @@
         <Company>Microsoft</Company>
         <Title>Microsoft.OpenApi</Title>
         <PackageId>Microsoft.ApiManagement.OpenApi</PackageId>
-        <Version>1.2.4-apim5</Version>
+        <Version>1.2.4-apim6</Version>
         <Description>.NET models with JSON and YAML writers for OpenAPI specification</Description>
         <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
         <PackageTags>OpenAPI .NET</PackageTags>

--- a/src/Microsoft.OpenApi/Writers/SpecialCharacterStringExtensions.cs
+++ b/src/Microsoft.OpenApi/Writers/SpecialCharacterStringExtensions.cs
@@ -187,9 +187,10 @@ namespace Microsoft.OpenApi.Writers
                 return $"'{input}'";
             }
 
-            // If string can be mistaken as a number, a boolean, or a timestamp,
-            // wrap it in quote to indicate that this is indeed a string, not a number, a boolean, or a timestamp
+            // If string can be mistaken as a number, c-style hexadecimal notation, a boolean, or a timestamp,
+            // wrap it in quote to indicate that this is indeed a string, not a number, c-style hexadecimal notation, a boolean, or a timestamp
             if (decimal.TryParse(input, NumberStyles.Float, CultureInfo.InvariantCulture, out var _) ||
+                IsHexadecimalNotation(input) ||
                 bool.TryParse(input, out var _) ||
                 DateTime.TryParse(input, out var _))
             {
@@ -224,6 +225,11 @@ namespace Microsoft.OpenApi.Writers
             value = value.Replace("\"", "\\\"");
 
             return $"\"{value}\"";
+        }
+
+        internal static bool IsHexadecimalNotation(string input)
+        {
+            return input.StartsWith("0x") && int.TryParse(input.Substring(2), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var _);
         }
     }
 }

--- a/test/Microsoft.OpenApi.Tests/Writers/OpenApiWriterSpecialCharacterTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Writers/OpenApiWriterSpecialCharacterTests.cs
@@ -29,6 +29,7 @@ namespace Microsoft.OpenApi.Tests.Writers
         [InlineData("Test\\Test", "\"Test\\\\Test\"")]
         [InlineData("Test\"Test", "\"Test\\\"Test\"")]
         [InlineData("StringsWith\"Quotes\"", "\"StringsWith\\\"Quotes\\\"\"")]
+        [InlineData("0x1234", "\"0x1234\"")]
         public void WriteStringWithSpecialCharactersAsJsonWorks(string input, string expected)
         {
             // Arrange


### PR DESCRIPTION
* Updated version from 1.2.4-apim5 to 1.2.4-apim6
* Added fix to identify and wrap c-style, hex notation strings as a string