### PR TITLE
[bugfix] add long \ DateTime \ DateTimeOffset support

### DIFF
--- a/src/Microsoft.OpenApi/Writers/IOpenApiWriter.cs
+++ b/src/Microsoft.OpenApi/Writers/IOpenApiWriter.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. 
 
+using System;
+
 namespace Microsoft.OpenApi.Writers
 {
     /// <summary>
@@ -42,6 +44,21 @@ namespace Microsoft.OpenApi.Writers
         /// Write the decimal value.
         /// </summary>
         void WriteValue(decimal value);
+
+        /// <summary>
+        /// Write the long value.
+        /// </summary>
+        void WriteValue(long value);
+        
+        /// <summary>
+        /// Write the DateTime value.
+        /// </summary>
+        void WriteValue(DateTime value);
+        
+        /// <summary>
+        /// Write the DateTimeOffset value.
+        /// </summary>
+        void WriteValue(DateTimeOffset value);
 
         /// <summary>
         /// Write the int value.

--- a/test/Microsoft.OpenApi.Tests/Wrappers/OpenApiJTokenWriter.cs
+++ b/test/Microsoft.OpenApi.Tests/Wrappers/OpenApiJTokenWriter.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using Microsoft.OpenApi.Writers;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.OpenApi.Tests.Wrappers
+{
+    public class OpenApiJTokenWriter : IOpenApiWriter
+    {
+        readonly JTokenWriter writer = new JTokenWriter();
+
+        public JToken Token
+            => this.writer.Token;
+
+        public void Flush()
+            => this.writer.Flush();
+
+        public void WriteEndArray()
+            => this.writer.WriteEndArray();
+
+        public void WriteEndObject()
+            => this.writer.WriteEndObject();
+
+        public void WriteNull()
+            => this.writer.WriteNull();
+
+        public void WritePropertyName(string name)
+            => this.writer.WritePropertyName(name);
+
+        public void WriteRaw(string value)
+            => throw new InvalidOperationException();
+
+        public void WriteStartArray()
+            => this.writer.WriteStartArray();
+
+        public void WriteStartObject()
+            => this.writer.WriteStartObject();
+
+        public void WriteValue(string value)
+            => this.writer.WriteValue(value);
+
+        public void WriteValue(long value)
+            => this.writer.WriteValue(value);
+        
+        public void WriteValue(decimal value)
+            => this.writer.WriteValue(value);
+
+        public void WriteValue(int value)
+            => this.writer.WriteValue(value);
+
+        public void WriteValue(bool value)
+            => this.writer.WriteValue(value);
+
+        /// <summary>
+        /// Writes date-time format according to openapi spec
+        /// https://swagger.io/docs/specification/data-models/data-types/
+        /// https://datatracker.ietf.org/doc/html/rfc3339#section-5.6
+        /// for example, 2017-07-21
+        /// </summary>
+        /// <param name="value"></param>
+        public void WriteValue(DateTime value)
+            => this.WriteValue(value.ToString("yyyy-MM-dd"));
+
+        /// <summary>
+        /// Writes date-time format according to openapi spec
+        /// https://swagger.io/docs/specification/data-models/data-types/
+        /// https://datatracker.ietf.org/doc/html/rfc3339#section-5.6
+        /// for example, 2017-07-21T17:32:28Z
+        /// </summary>
+        /// <param name="value"></param>
+        public void WriteValue(DateTimeOffset value)
+            => this.WriteValue(value.ToString("yyyy-MM-ddThh:mm:ss"));
+
+        public void WriteValue(object value)
+            => this.writer.WriteValue(value);
+    }
+}

--- a/test/Microsoft.OpenApi.Tests/Writers/OpenApiJsonWriterTests.cs
+++ b/test/Microsoft.OpenApi.Tests/Writers/OpenApiJsonWriterTests.cs
@@ -8,8 +8,11 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using FluentAssertions;
+using Microsoft.OpenApi.Any;
+using Microsoft.OpenApi.Tests.Wrappers;
 using Microsoft.OpenApi.Writers;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -271,6 +274,45 @@ namespace Microsoft.OpenApi.Tests.Writers
 
             // Assert
             writtenString.Should().Be(expectedString);
+        }
+        
+        [Fact]
+        public void PrimitiveTypeWrite_OutputsInDesiredFormat_WhenIsLongPrimitive()
+        {
+            long value = 12345;
+            var longPrimitive = new OpenApiLong(value);
+
+            var writer = new OpenApiJTokenWriter();
+            longPrimitive.Write(writer, OpenApiSpecVersion.OpenApi3_0);
+
+            var result = writer.Token.ToString();
+            result.Should().Be("12345");
+        }
+        
+        [Fact]
+        public void PrimitiveTypeWrite_OutputsInDesiredFormat_WhenIsDateTimeOffsetPrimitive()
+        {
+            DateTimeOffset now = DateTimeOffset.Parse("2020-10-04T10:41:26");
+            var dateTimePrimitive = new OpenApiDateTime(now);
+
+            var writer = new OpenApiJTokenWriter();
+            dateTimePrimitive.Write(writer, OpenApiSpecVersion.OpenApi3_0);
+
+            var result = writer.Token.ToString();
+            result.Should().Be("2020-10-04T10:41:26");
+        }
+        
+        [Fact]
+        public void PrimitiveTypeWrite_OutputsInDesiredFormat_WhenIsDateTimePrimitive()
+        {
+            DateTime now = DateTime.Parse("2020-10-04");
+            var dateTimePrimitive = new OpenApiDate(now);
+
+            var writer = new OpenApiJTokenWriter();
+            dateTimePrimitive.Write(writer, OpenApiSpecVersion.OpenApi3_0);
+
+            var result = writer.Token.ToString();
+            result.Should().Be("2020-10-04");
         }
     }
 }


### PR DESCRIPTION
Lack of overloads in `IOpenApiWriter` for some primitives (i.e. `long`, `DateTime` and `DateTimeOffset`) leads to incorrect write output result.

1) `example: 12345` is converted to `OpenApiLong` and then falls into `Decimal` overload, which ends up writing as a "float" number in JTokenWriter (inside of newtonsoftJson inner writer).
2) `example: "2020-10-04T10:41:26"` is converted into `example": "2020-10-04T10:41:26.0000000+00:00"`, which is wrong according to https://swagger.io/docs/specification/data-models/data-types/ and https://datatracker.ietf.org/doc/html/rfc3339#section-5.6.

I have added required overloads in current PR + tested to ensure output is correct