### PR TITLE
Fix overflow bug to gracefully handle very large values in schemas

### DIFF
--- a/src/Microsoft.OpenApi.Readers/ParseNodes/ParserHelper.cs
+++ b/src/Microsoft.OpenApi.Readers/ParseNodes/ParserHelper.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+using System;
+using System.Globalization;
+
+namespace Microsoft.OpenApi.Readers.ParseNodes
+{
+    /// <summary>
+    /// Useful tools to parse data
+    /// </summary>
+    internal class ParserHelper
+    {
+        /// <summary>
+        /// Parses decimal in invariant culture.
+        /// If the decimal is too big or small, it returns the default value
+        /// 
+        /// Note: sometimes developers put Double.MaxValue or Long.MaxValue as min/max values for numbers in json schema even if their numbers are not expected to be that big/small.
+        /// As we have already released the library with Decimal type for Max/Min, let's not introduce the breaking change and just fallback to Decimal.Max / Min. This should satisfy almost every scenario.
+        /// We can revisit this if somebody really needs to have double or long here.
+        /// </summary>
+        /// <returns></returns>
+        public static decimal ParseDecimalWithFallbackOnOverflow(string value, decimal defaultValue)
+        {
+            try
+            {
+                return decimal.Parse(value, NumberStyles.Float, CultureInfo.InvariantCulture);
+            }
+            catch (OverflowException)
+            {
+                return defaultValue;
+            }
+        }
+    }
+}

--- a/src/Microsoft.OpenApi.Readers/V2/OpenApiHeaderDeserializer.cs
+++ b/src/Microsoft.OpenApi.Readers/V2/OpenApiHeaderDeserializer.cs
@@ -1,5 +1,5 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license. 
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
 
 using System;
 using System.Globalization;
@@ -16,150 +16,114 @@ namespace Microsoft.OpenApi.Readers.V2
     /// </summary>
     internal static partial class OpenApiV2Deserializer
     {
-        private static readonly FixedFieldMap<OpenApiHeader> _headerFixedFields = new FixedFieldMap<OpenApiHeader>
+        private static readonly FixedFieldMap<OpenApiHeader> _headerFixedFields = new()
         {
             {
-                "description", (o, n) =>
-                {
-                    o.Description = n.GetScalarValue();
-                }
+                "description",
+                (o, n) => o.Description = n.GetScalarValue()
             },
             {
-                "type", (o, n) =>
-                {
-                    GetOrCreateSchema(o).Type = n.GetScalarValue();
-                }
+                "type",
+                (o, n) => GetOrCreateSchema(o).Type = n.GetScalarValue()
             },
             {
-                "format", (o, n) =>
-                {
-                    GetOrCreateSchema(o).Format = n.GetScalarValue();
-                }
+                "format",
+                (o, n) => GetOrCreateSchema(o).Format = n.GetScalarValue()
             },
             {
-                "items", (o, n) =>
-                {
-                    GetOrCreateSchema(o).Items = LoadSchema(n);
-                }
+                "items",
+                (o, n) => GetOrCreateSchema(o).Items = LoadSchema(n)
             },
             {
-                "collectionFormat", (o, n) =>
-                {
-                    LoadStyle(o, n.GetScalarValue());
-                }
+                "collectionFormat",
+                (o, n) => LoadStyle(o, n.GetScalarValue())
             },
             {
-                "default", (o, n) =>
-                {
-                    GetOrCreateSchema(o).Default = n.CreateAny();
-                }
+                "default",
+                (o, n) => GetOrCreateSchema(o).Default = n.CreateAny()
             },
             {
-                "maximum", (o, n) =>
-                {
-                    GetOrCreateSchema(o).Maximum = decimal.Parse(n.GetScalarValue(), CultureInfo.InvariantCulture);
-                }
+                "maximum",
+                (o, n) => GetOrCreateSchema(o).Maximum = ParserHelper.ParseDecimalWithFallbackOnOverflow(n.GetScalarValue(), decimal.MaxValue)
             },
             {
-                "exclusiveMaximum", (o, n) =>
-                {
-                    GetOrCreateSchema(o).ExclusiveMaximum = bool.Parse(n.GetScalarValue());
-                }
+                "exclusiveMaximum",
+                (o, n) => GetOrCreateSchema(o).ExclusiveMaximum = bool.Parse(n.GetScalarValue())
             },
             {
-                "minimum", (o, n) =>
-                {
-                    GetOrCreateSchema(o).Minimum = decimal.Parse(n.GetScalarValue(), CultureInfo.InvariantCulture);
-                }
+                "minimum",
+                (o, n) => GetOrCreateSchema(o).Minimum = ParserHelper.ParseDecimalWithFallbackOnOverflow(n.GetScalarValue(), decimal.MinValue)
             },
             {
-                "exclusiveMinimum", (o, n) =>
-                {
-                    GetOrCreateSchema(o).ExclusiveMinimum = bool.Parse(n.GetScalarValue());
-                }
+                "exclusiveMinimum",
+                (o, n) => GetOrCreateSchema(o).ExclusiveMinimum = bool.Parse(n.GetScalarValue())
             },
             {
-                "maxLength", (o, n) =>
-                {
-                    GetOrCreateSchema(o).MaxLength = int.Parse(n.GetScalarValue(), CultureInfo.InvariantCulture);
-                }
+                "maxLength",
+                (o, n) => GetOrCreateSchema(o).MaxLength = int.Parse(n.GetScalarValue(), CultureInfo.InvariantCulture)
             },
             {
-                "minLength", (o, n) =>
-                {
-                    GetOrCreateSchema(o).MinLength = int.Parse(n.GetScalarValue(), CultureInfo.InvariantCulture);
-                }
+                "minLength",
+                (o, n) => GetOrCreateSchema(o).MinLength = int.Parse(n.GetScalarValue(), CultureInfo.InvariantCulture)
             },
             {
-                "pattern", (o, n) =>
-                {
-                    GetOrCreateSchema(o).Pattern = n.GetScalarValue();
-                }
+                "pattern",
+                (o, n) => GetOrCreateSchema(o).Pattern = n.GetScalarValue()
             },
             {
-                "maxItems", (o, n) =>
-                {
-                    GetOrCreateSchema(o).MaxItems = int.Parse(n.GetScalarValue(), CultureInfo.InvariantCulture);
-                }
+                "maxItems",
+                (o, n) => GetOrCreateSchema(o).MaxItems = int.Parse(n.GetScalarValue(), CultureInfo.InvariantCulture)
             },
             {
-                "minItems", (o, n) =>
-                {
-                    GetOrCreateSchema(o).MinItems = int.Parse(n.GetScalarValue(), CultureInfo.InvariantCulture);
-                }
+                "minItems",
+                (o, n) => GetOrCreateSchema(o).MinItems = int.Parse(n.GetScalarValue(), CultureInfo.InvariantCulture)
             },
             {
-                "uniqueItems", (o, n) =>
-                {
-                    GetOrCreateSchema(o).UniqueItems = bool.Parse(n.GetScalarValue());
-                }
+                "uniqueItems",
+                (o, n) => GetOrCreateSchema(o).UniqueItems = bool.Parse(n.GetScalarValue())
             },
             {
-                "multipleOf", (o, n) =>
-                {
-                    GetOrCreateSchema(o).MultipleOf = decimal.Parse(n.GetScalarValue(), CultureInfo.InvariantCulture);
-                }
+                "multipleOf",
+                (o, n) => GetOrCreateSchema(o).MultipleOf = decimal.Parse(n.GetScalarValue(), CultureInfo.InvariantCulture)
             },
             {
-                "enum", (o, n) =>
-                {
-                    GetOrCreateSchema(o).Enum = n.CreateListOfAny();
-                }
+                "enum",
+                (o, n) => GetOrCreateSchema(o).Enum = n.CreateListOfAny()
             }
         };
 
-        private static readonly PatternFieldMap<OpenApiHeader> _headerPatternFields = new PatternFieldMap<OpenApiHeader>
+        private static readonly PatternFieldMap<OpenApiHeader> _headerPatternFields = new()
         {
             {s => s.StartsWith("x-"), (o, p, n) => o.AddExtension(p, LoadExtension(p, n))}
         };
 
         private static readonly AnyFieldMap<OpenApiHeader> _headerAnyFields =
-            new AnyFieldMap<OpenApiHeader>
+            new()
             {
                 {
                     OpenApiConstants.Default,
-                    new AnyFieldMapParameter<OpenApiHeader>(
+                    new(
                         p => p.Schema?.Default,
-                        (p, v) => 
+                        (p, v) =>
                         {
                             if(p.Schema == null) return;
-                            p.Schema.Default = v; 
+                            p.Schema.Default = v;
                         },
                         p => p.Schema)
                 }
             };
 
         private static readonly AnyListFieldMap<OpenApiHeader> _headerAnyListFields =
-            new AnyListFieldMap<OpenApiHeader>
+            new()
             {
                 {
                     OpenApiConstants.Enum,
-                    new AnyListFieldMapParameter<OpenApiHeader>(
+                    new(
                         p => p.Schema?.Enum,
                         (p, v) =>
                         {
                             if(p.Schema == null) return;
-                            p.Schema.Enum = v; 
+                            p.Schema.Enum = v;
                         },
                         p => p.Schema)
                 },

--- a/src/Microsoft.OpenApi.Readers/V2/OpenApiParameterDeserializer.cs
+++ b/src/Microsoft.OpenApi.Readers/V2/OpenApiParameterDeserializer.cs
@@ -1,5 +1,5 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license. 
+// Licensed under the MIT license.
 
 using System;
 using System.Collections.Generic;
@@ -17,136 +17,98 @@ namespace Microsoft.OpenApi.Readers.V2
     internal static partial class OpenApiV2Deserializer
     {
         private static readonly FixedFieldMap<OpenApiParameter> _parameterFixedFields =
-            new FixedFieldMap<OpenApiParameter>
+            new()
             {
                 {
-                    "name", (o, n) =>
-                    {
-                        o.Name = n.GetScalarValue();
-                    }
+                    "name",
+                    (o, n) => o.Name = n.GetScalarValue()
                 },
                 {
-                    "in", (o, n) =>
-                    {
-                        ProcessIn(o, n);
-                    }
+                    "in",
+                    ProcessIn
                 },
                 {
-                    "description", (o, n) =>
-                    {
-                        o.Description = n.GetScalarValue();
-                    }
+                    "description",
+                    (o, n) => o.Description = n.GetScalarValue()
                 },
                 {
-                    "required", (o, n) =>
-                    {
-                        o.Required = bool.Parse(n.GetScalarValue());
-                    }
+                    "required",
+                    (o, n) => o.Required = bool.Parse(n.GetScalarValue())
                 },
                 {
-                    "deprecated", (o, n) =>
-                    {
-                        o.Deprecated = bool.Parse(n.GetScalarValue());
-                    }
+                    "deprecated",
+                    (o, n) => o.Deprecated = bool.Parse(n.GetScalarValue())
                 },
                 {
-                    "allowEmptyValue", (o, n) =>
-                    {
-                        o.AllowEmptyValue = bool.Parse(n.GetScalarValue());
-                    }
+                    "allowEmptyValue",
+                    (o, n) => o.AllowEmptyValue = bool.Parse(n.GetScalarValue())
                 },
                 {
-                    "type", (o, n) =>
-                    {
-                        GetOrCreateSchema(o).Type = n.GetScalarValue();
-                    }
+                    "type",
+                    (o, n) => GetOrCreateSchema(o).Type = n.GetScalarValue()
                 },
                 {
-                    "items", (o, n) =>
-                    {
-                        GetOrCreateSchema(o).Items = LoadSchema(n);
-                    }
+                    "items",
+                    (o, n) => GetOrCreateSchema(o).Items = LoadSchema(n)
                 },
                 {
-                    "collectionFormat", (o, n) =>
-                    {
-                        LoadStyle(o, n.GetScalarValue());
-                    }
+                    "collectionFormat",
+                    (o, n) => LoadStyle(o, n.GetScalarValue())
                 },
                 {
-                    "format", (o, n) =>
-                    {
-                        GetOrCreateSchema(o).Format = n.GetScalarValue();
-                    }
+                    "format",
+                    (o, n) => GetOrCreateSchema(o).Format = n.GetScalarValue()
                 },
                 {
-                    "minimum", (o, n) =>
-                    {
-                        GetOrCreateSchema(o).Minimum = decimal.Parse(n.GetScalarValue(), CultureInfo.InvariantCulture);
-                    }
+                    "minimum",
+                    (o, n) => GetOrCreateSchema(o).Minimum = ParserHelper.ParseDecimalWithFallbackOnOverflow(n.GetScalarValue(), decimal.MinValue)
                 },
                 {
-                    "maximum", (o, n) =>
-                    {
-                        GetOrCreateSchema(o).Maximum = decimal.Parse(n.GetScalarValue(), CultureInfo.InvariantCulture);
-                    }
+                    "maximum",
+                    (o, n) => GetOrCreateSchema(o).Maximum = ParserHelper.ParseDecimalWithFallbackOnOverflow(n.GetScalarValue(), decimal.MaxValue)
                 },
                 {
-                    "maxLength", (o, n) =>
-                    {
-                        GetOrCreateSchema(o).MaxLength = int.Parse(n.GetScalarValue(), CultureInfo.InvariantCulture);
-                    }
+                    "maxLength",
+                    (o, n) => GetOrCreateSchema(o).MaxLength = int.Parse(n.GetScalarValue(), CultureInfo.InvariantCulture)
                 },
                 {
-                    "minLength", (o, n) =>
-                    {
-                        GetOrCreateSchema(o).MinLength = int.Parse(n.GetScalarValue(), CultureInfo.InvariantCulture);
-                    }
+                    "minLength",
+                    (o, n) => GetOrCreateSchema(o).MinLength = int.Parse(n.GetScalarValue(), CultureInfo.InvariantCulture)
                 },
                 {
-                    "readOnly", (o, n) =>
-                    {
-                        GetOrCreateSchema(o).ReadOnly = bool.Parse(n.GetScalarValue());
-                    }
+                    "readOnly",
+                    (o, n) => GetOrCreateSchema(o).ReadOnly = bool.Parse(n.GetScalarValue())
                 },
                 {
-                    "default", (o, n) =>
-                    {
-                        GetOrCreateSchema(o).Default = n.CreateAny();
-                    }
+                    "default",
+                    (o, n) => GetOrCreateSchema(o).Default = n.CreateAny()
                 },
                 {
-                    "pattern", (o, n) =>
-                    {
-                        GetOrCreateSchema(o).Pattern = n.GetScalarValue();
-                    }
+                    "pattern",
+                    (o, n) => GetOrCreateSchema(o).Pattern = n.GetScalarValue()
                 },
                 {
-                    "enum", (o, n) =>
-                    {
-                        GetOrCreateSchema(o).Enum = n.CreateListOfAny();
-                    }
+                    "enum",
+                    (o, n) => GetOrCreateSchema(o).Enum = n.CreateListOfAny()
                 },
                 {
-                    "schema", (o, n) =>
-                    {
-                        o.Schema = LoadSchema(n);
-                    }
+                    "schema",
+                    (o, n) => o.Schema = LoadSchema(n)
                 },
             };
 
         private static readonly PatternFieldMap<OpenApiParameter> _parameterPatternFields =
-            new PatternFieldMap<OpenApiParameter>
+            new()
             {
                 {s => s.StartsWith("x-"), (o, p, n) => o.AddExtension(p, LoadExtension(p, n))}
             };
 
         private static readonly AnyFieldMap<OpenApiParameter> _parameterAnyFields =
-            new AnyFieldMap<OpenApiParameter>
+            new()
             {
                 {
                     OpenApiConstants.Default,
-                    new AnyFieldMapParameter<OpenApiParameter>(
+                    new(
                         p => p.Schema?.Default,
                         (p, v) => {
                             if (p.Schema != null || v != null)
@@ -159,14 +121,14 @@ namespace Microsoft.OpenApi.Readers.V2
             };
 
         private static readonly AnyListFieldMap<OpenApiParameter> _parameterAnyListFields =
-            new AnyListFieldMap<OpenApiParameter>
+            new()
             {
                 {
                     OpenApiConstants.Enum,
-                    new AnyListFieldMapParameter<OpenApiParameter>(
+                    new(
                         p => p.Schema?.Enum,
                         (p, v) => {
-                            if (p.Schema != null || v != null && v.Count > 0)
+                            if (p.Schema != null || v is {Count: > 0})
                             {
                                 GetOrCreateSchema(p).Enum = v;
                             }
@@ -208,7 +170,7 @@ namespace Microsoft.OpenApi.Readers.V2
         {
             if (p.Schema == null)
             {
-                p.Schema = new OpenApiSchema();
+                p.Schema = new();
             }
 
             return p.Schema;
@@ -218,7 +180,7 @@ namespace Microsoft.OpenApi.Readers.V2
         {
             if (p.Schema == null)
             {
-                p.Schema = new OpenApiSchema();
+                p.Schema = new();
             }
 
             return p.Schema;
@@ -238,7 +200,7 @@ namespace Microsoft.OpenApi.Readers.V2
                     var formParameters = n.Context.GetFromTempStorage<List<OpenApiParameter>>("formParameters");
                     if (formParameters == null)
                     {
-                        formParameters = new List<OpenApiParameter>();
+                        formParameters = new();
                         n.Context.SetTempStorage("formParameters", formParameters);
                     }
 
@@ -288,7 +250,7 @@ namespace Microsoft.OpenApi.Readers.V2
                 node.Context.SetTempStorage("schema", null);
             }
 
-            bool isBodyOrFormData = (bool)node.Context.GetFromTempStorage<object>(TempStorageKeys.ParameterIsBodyOrFormData);
+            var isBodyOrFormData = (bool)node.Context.GetFromTempStorage<object>(TempStorageKeys.ParameterIsBodyOrFormData);
             if (isBodyOrFormData && !loadRequestBody)
             {
                 return null; // Don't include Form or Body parameters when normal parameters are loaded.

--- a/src/Microsoft.OpenApi.Readers/V2/OpenApiSchemaDeserializer.cs
+++ b/src/Microsoft.OpenApi.Readers/V2/OpenApiSchemaDeserializer.cs
@@ -1,5 +1,5 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license. 
+// Licensed under the MIT license.
 
 using System.Collections.Generic;
 using System.Globalization;
@@ -15,128 +15,88 @@ namespace Microsoft.OpenApi.Readers.V2
     /// </summary>
     internal static partial class OpenApiV2Deserializer
     {
-        private static readonly FixedFieldMap<OpenApiSchema> _schemaFixedFields = new FixedFieldMap<OpenApiSchema>
+        private static readonly FixedFieldMap<OpenApiSchema> _schemaFixedFields = new()
         {
             {
-                "title", (o, n) =>
-                {
-                    o.Title = n.GetScalarValue();
-                }
+                "title",
+                (o, n) => o.Title = n.GetScalarValue()
             },
             {
-                "multipleOf", (o, n) =>
-                {
-                    o.MultipleOf = decimal.Parse(n.GetScalarValue(), NumberStyles.Float, CultureInfo.InvariantCulture);
-                }
+                "multipleOf",
+                (o, n) => o.MultipleOf = decimal.Parse(n.GetScalarValue(), NumberStyles.Float, CultureInfo.InvariantCulture)
             },
             {
-                "maximum", (o, n) =>
-                {
-                    o.Maximum = decimal.Parse(n.GetScalarValue(), NumberStyles.Float, CultureInfo.InvariantCulture);
-                }
+                "maximum",
+                (o, n) => o.Maximum = ParserHelper.ParseDecimalWithFallbackOnOverflow(n.GetScalarValue(), decimal.MaxValue)
             },
             {
-                "exclusiveMaximum", (o, n) =>
-                {
-                    o.ExclusiveMaximum = bool.Parse(n.GetScalarValue());
-                }
+                "exclusiveMaximum",
+                (o, n) => o.ExclusiveMaximum = bool.Parse(n.GetScalarValue())
             },
             {
-                "minimum", (o, n) =>
-                {
-                    o.Minimum = decimal.Parse(n.GetScalarValue(), NumberStyles.Float, CultureInfo.InvariantCulture);
-                }
+                "minimum",
+                (o, n) => o.Minimum = ParserHelper.ParseDecimalWithFallbackOnOverflow(n.GetScalarValue(), decimal.MinValue)
             },
             {
-                "exclusiveMinimum", (o, n) =>
-                {
-                    o.ExclusiveMinimum = bool.Parse(n.GetScalarValue());
-                }
+                "exclusiveMinimum",
+                (o, n) => o.ExclusiveMinimum = bool.Parse(n.GetScalarValue())
             },
             {
-                "maxLength", (o, n) =>
-                {
-                    o.MaxLength = int.Parse(n.GetScalarValue(), CultureInfo.InvariantCulture);
-                }
+                "maxLength",
+                (o, n) => o.MaxLength = int.Parse(n.GetScalarValue(), CultureInfo.InvariantCulture)
             },
             {
-                "minLength", (o, n) =>
-                {
-                    o.MinLength = int.Parse(n.GetScalarValue(), CultureInfo.InvariantCulture);
-                }
+                "minLength",
+                (o, n) => o.MinLength = int.Parse(n.GetScalarValue(), CultureInfo.InvariantCulture)
             },
             {
-                "pattern", (o, n) =>
-                {
-                    o.Pattern = n.GetScalarValue();
-                }
+                "pattern",
+                (o, n) => o.Pattern = n.GetScalarValue()
             },
             {
-                "maxItems", (o, n) =>
-                {
-                    o.MaxItems = int.Parse(n.GetScalarValue(), CultureInfo.InvariantCulture);
-                }
+                "maxItems",
+                (o, n) => o.MaxItems = int.Parse(n.GetScalarValue(), CultureInfo.InvariantCulture)
             },
             {
-                "minItems", (o, n) =>
-                {
-                    o.MinItems = int.Parse(n.GetScalarValue(), CultureInfo.InvariantCulture);
-                }
+                "minItems",
+                (o, n) => o.MinItems = int.Parse(n.GetScalarValue(), CultureInfo.InvariantCulture)
             },
             {
-                "uniqueItems", (o, n) =>
-                {
-                    o.UniqueItems = bool.Parse(n.GetScalarValue());
-                }
+                "uniqueItems",
+                (o, n) => o.UniqueItems = bool.Parse(n.GetScalarValue())
             },
             {
-                "maxProperties", (o, n) =>
-                {
-                    o.MaxProperties = int.Parse(n.GetScalarValue(), CultureInfo.InvariantCulture);
-                }
+                "maxProperties",
+                (o, n) => o.MaxProperties = int.Parse(n.GetScalarValue(), CultureInfo.InvariantCulture)
             },
             {
-                "minProperties", (o, n) =>
-                {
-                    o.MinProperties = int.Parse(n.GetScalarValue(), CultureInfo.InvariantCulture);
-                }
+                "minProperties",
+                (o, n) => o.MinProperties = int.Parse(n.GetScalarValue(), CultureInfo.InvariantCulture)
             },
             {
-                "required", (o, n) =>
-                {
-                    o.Required = new HashSet<string>(n.CreateSimpleList(n2 => n2.GetScalarValue()));
-                }
+                "required",
+                (o, n) => o.Required = new HashSet<string>(n.CreateSimpleList(n2 => n2.GetScalarValue()))
             },
             {
-                "enum", (o, n) =>
-                {
-                    o.Enum = n.CreateListOfAny();
-                }
+                "enum",
+                (o, n) => o.Enum = n.CreateListOfAny()
             },
 
             {
-                "type", (o, n) =>
-                {
-                    o.Type = n.GetScalarValue();
-                }
+                "type",
+                (o, n) => o.Type = n.GetScalarValue()
             },
             {
-                "allOf", (o, n) =>
-                {
-                    o.AllOf = n.CreateList(LoadSchema);
-                }
+                "allOf",
+                (o, n) => o.AllOf = n.CreateList(LoadSchema)
             },
             {
-                "items", (o, n) =>
-                {
-                    o.Items = LoadSchema(n);
-                }
+                "items",
+                (o, n) => o.Items = LoadSchema(n)
             },
             {
-                "properties", (o, n) =>
-                {
-                    o.Properties = n.CreateMap(LoadSchema);
-                }
+                "properties",
+                (o, n) => o.Properties = n.CreateMap(LoadSchema)
             },
             {
                 "additionalProperties", (o, n) =>
@@ -152,85 +112,71 @@ namespace Microsoft.OpenApi.Readers.V2
                 }
             },
             {
-                "description", (o, n) =>
-                {
-                    o.Description = n.GetScalarValue();
-                }
+                "description",
+                (o, n) => o.Description = n.GetScalarValue()
             },
             {
-                "format", (o, n) =>
-                {
-                    o.Format = n.GetScalarValue();
-                }
+                "format",
+                (o, n) => o.Format = n.GetScalarValue()
             },
             {
-                "default", (o, n) =>
-                {
-                    o.Default = n.CreateAny();
-                }
+                "default",
+                (o, n) => o.Default = n.CreateAny()
             },
             {
                 "discriminator", (o, n) =>
                 {
-                    o.Discriminator = new OpenApiDiscriminator
+                    o.Discriminator = new()
                     {
                         PropertyName = n.GetScalarValue()
                     };
                 }
             },
             {
-                "readOnly", (o, n) =>
-                {
-                    o.ReadOnly = bool.Parse(n.GetScalarValue());
-                }
+                "readOnly",
+                (o, n) => o.ReadOnly = bool.Parse(n.GetScalarValue())
             },
             {
-                "xml", (o, n) =>
-                {
-                    o.Xml = LoadXml(n);
-                }
+                "xml",
+                (o, n) => o.Xml = LoadXml(n)
             },
             {
-                "externalDocs", (o, n) =>
-                {
-                    o.ExternalDocs = LoadExternalDocs(n);
-                }
+                "externalDocs",
+                (o, n) => o.ExternalDocs = LoadExternalDocs(n)
             },
             {
-                "example", (o, n) =>
-                {
-                    o.Example = n.CreateAny();
-                }
+                "example",
+                (o, n) => o.Example = n.CreateAny()
             },
         };
 
-        private static readonly PatternFieldMap<OpenApiSchema> _schemaPatternFields = new PatternFieldMap<OpenApiSchema>
+        private static readonly PatternFieldMap<OpenApiSchema> _schemaPatternFields = new()
         {
             {s => s.StartsWith("x-"), (o, p, n) => o.AddExtension(p, LoadExtension(p, n))}
         };
 
-        private static readonly AnyFieldMap<OpenApiSchema> _schemaAnyFields = new AnyFieldMap<OpenApiSchema>
+        private static readonly AnyFieldMap<OpenApiSchema> _schemaAnyFields = new()
         {
             {
                 OpenApiConstants.Default,
-                new AnyFieldMapParameter<OpenApiSchema>(
+                new(
                     s => s.Default,
                     (s, v) => s.Default = v,
                     s => s)
             },
             {
                 OpenApiConstants.Example,
-                new AnyFieldMapParameter<OpenApiSchema>(
+                new(
                     s => s.Example,
                     (s, v) => s.Example = v,
                     s => s) }
         };
 
-        private static readonly AnyListFieldMap<OpenApiSchema> _schemaAnyListFields = new AnyListFieldMap<OpenApiSchema>
+        private static readonly AnyListFieldMap<OpenApiSchema> _schemaAnyListFields = new()
         {
             {
                 OpenApiConstants.Enum,
-                new AnyListFieldMapParameter<OpenApiSchema>(
+                new(
                     s => s.Enum,
                     (s, v) => s.Enum = v,
                     s => s)

--- a/src/Microsoft.OpenApi.Readers/V3/OpenApiSchemaDeserializer.cs
+++ b/src/Microsoft.OpenApi.Readers/V3/OpenApiSchemaDeserializer.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license. 
+// Licensed under the MIT license.
 
-using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Extensions;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.Readers.ParseNodes;
@@ -16,145 +15,99 @@ namespace Microsoft.OpenApi.Readers.V3
     /// </summary>
     internal static partial class OpenApiV3Deserializer
     {
-        private static readonly FixedFieldMap<OpenApiSchema> _schemaFixedFields = new FixedFieldMap<OpenApiSchema>
+        private static readonly FixedFieldMap<OpenApiSchema> _schemaFixedFields = new()
         {
             {
-                "title", (o, n) =>
-                {
-                    o.Title = n.GetScalarValue();
-                }
+                "title",
+                (o, n) => o.Title = n.GetScalarValue()
             },
             {
-                "multipleOf", (o, n) =>
-                {
-                    o.MultipleOf = decimal.Parse(n.GetScalarValue(), NumberStyles.Float, CultureInfo.InvariantCulture); 
-                }
+                "multipleOf",
+                (o, n) => o.MultipleOf = decimal.Parse(n.GetScalarValue(), NumberStyles.Float, CultureInfo.InvariantCulture)
             },
             {
-                "maximum", (o, n) =>
-                {
-                    o.Maximum = decimal.Parse(n.GetScalarValue(), NumberStyles.Float, CultureInfo.InvariantCulture);
-                }
+                "maximum",
+                (o, n) => o.Maximum = ParserHelper.ParseDecimalWithFallbackOnOverflow(n.GetScalarValue(), decimal.MaxValue)
             },
             {
-                "exclusiveMaximum", (o, n) =>
-                {
-                    o.ExclusiveMaximum = bool.Parse(n.GetScalarValue());
-                }
+                "exclusiveMaximum",
+                (o, n) => o.ExclusiveMaximum = bool.Parse(n.GetScalarValue())
             },
             {
-                "minimum", (o, n) =>
-                {
-                    o.Minimum = decimal.Parse(n.GetScalarValue(), NumberStyles.Float, CultureInfo.InvariantCulture);
-                }
+                "minimum",
+                (o, n) => o.Minimum = ParserHelper.ParseDecimalWithFallbackOnOverflow(n.GetScalarValue(), decimal.MinValue)
             },
             {
-                "exclusiveMinimum", (o, n) =>
-                {
-                    o.ExclusiveMinimum = bool.Parse(n.GetScalarValue());
-                }
+                "exclusiveMinimum",
+                (o, n) => o.ExclusiveMinimum = bool.Parse(n.GetScalarValue())
             },
             {
-                "maxLength", (o, n) =>
-                {
-                    o.MaxLength = int.Parse(n.GetScalarValue(), CultureInfo.InvariantCulture);
-                }
+                "maxLength",
+                (o, n) => o.MaxLength = int.Parse(n.GetScalarValue(), CultureInfo.InvariantCulture)
             },
             {
-                "minLength", (o, n) =>
-                {
-                    o.MinLength = int.Parse(n.GetScalarValue(), CultureInfo.InvariantCulture);
-                }
+                "minLength",
+                (o, n) => o.MinLength = int.Parse(n.GetScalarValue(), CultureInfo.InvariantCulture)
             },
             {
-                "pattern", (o, n) =>
-                {
-                    o.Pattern = n.GetScalarValue();
-                }
+                "pattern",
+                (o, n) => o.Pattern = n.GetScalarValue()
             },
             {
-                "maxItems", (o, n) =>
-                {
-                    o.MaxItems = int.Parse(n.GetScalarValue(), CultureInfo.InvariantCulture);
-                }
+                "maxItems",
+                (o, n) => o.MaxItems = int.Parse(n.GetScalarValue(), CultureInfo.InvariantCulture)
             },
             {
-                "minItems", (o, n) =>
-                {
-                    o.MinItems = int.Parse(n.GetScalarValue(), CultureInfo.InvariantCulture);
-                }
+                "minItems",
+                (o, n) => o.MinItems = int.Parse(n.GetScalarValue(), CultureInfo.InvariantCulture)
             },
             {
-                "uniqueItems", (o, n) =>
-                {
-                    o.UniqueItems = bool.Parse(n.GetScalarValue());
-                }
+                "uniqueItems",
+                (o, n) => o.UniqueItems = bool.Parse(n.GetScalarValue())
             },
             {
-                "maxProperties", (o, n) =>
-                {
-                    o.MaxProperties = int.Parse(n.GetScalarValue(), CultureInfo.InvariantCulture);
-                }
+                "maxProperties",
+                (o, n) => o.MaxProperties = int.Parse(n.GetScalarValue(), CultureInfo.InvariantCulture)
             },
             {
-                "minProperties", (o, n) =>
-                {
-                    o.MinProperties = int.Parse(n.GetScalarValue(), CultureInfo.InvariantCulture);
-                }
+                "minProperties",
+                (o, n) => o.MinProperties = int.Parse(n.GetScalarValue(), CultureInfo.InvariantCulture)
             },
             {
-                "required", (o, n) =>
-                {
-                    o.Required = new HashSet<string>(n.CreateSimpleList(n2 => n2.GetScalarValue()));
-                }
+                "required",
+                (o, n) => o.Required = new HashSet<string>(n.CreateSimpleList(n2 => n2.GetScalarValue()))
             },
             {
-                "enum", (o, n) =>
-                {
-                    o.Enum = n.CreateListOfAny();
-                }
+                "enum",
+                (o, n) => o.Enum = n.CreateListOfAny()
             },
             {
-                "type", (o, n) =>
-                {
-                    o.Type = n.GetScalarValue();
-                }
+                "type",
+                (o, n) => o.Type = n.GetScalarValue()
             },
             {
-                "allOf", (o, n) =>
-                {
-                    o.AllOf = n.CreateList(LoadSchema);
-                }
+                "allOf",
+                (o, n) => o.AllOf = n.CreateList(LoadSchema)
             },
             {
-                "oneOf", (o, n) =>
-                {
-                    o.OneOf = n.CreateList(LoadSchema);
-                }
+                "oneOf",
+                (o, n) => o.OneOf = n.CreateList(LoadSchema)
             },
             {
-                "anyOf", (o, n) =>
-                {
-                    o.AnyOf = n.CreateList(LoadSchema);
-                }
+                "anyOf",
+                (o, n) => o.AnyOf = n.CreateList(LoadSchema)
             },
             {
-                "not", (o, n) =>
-                {
-                    o.Not = LoadSchema(n);
-                }
+                "not",
+                (o, n) => o.Not = LoadSchema(n)
             },
             {
-                "items", (o, n) =>
-                {
-                    o.Items = LoadSchema(n);
-                }
+                "items",
+                (o, n) => o.Items = LoadSchema(n)
             },
             {
-                "properties", (o, n) =>
-                {
-                    o.Properties = n.CreateMap(LoadSchema);
-                }
+                "properties",
+                (o, n) => o.Properties = n.CreateMap(LoadSchema)
             },
             {
                 "additionalProperties", (o, n) =>
@@ -170,102 +123,79 @@ namespace Microsoft.OpenApi.Readers.V3
                 }
             },
             {
-                "description", (o, n) =>
-                {
-                    o.Description = n.GetScalarValue();
-                }
+                "description",
+                (o, n) => o.Description = n.GetScalarValue()
             },
             {
-                "format", (o, n) =>
-                {
-                    o.Format = n.GetScalarValue();
-                }
+                "format",
+                (o, n) => o.Format = n.GetScalarValue()
             },
             {
-                "default", (o, n) =>
-                {
-                    o.Default = n.CreateAny();
-                }
-            },
-
-            {
-                "nullable", (o, n) =>
-                {
-                    o.Nullable = bool.Parse(n.GetScalarValue());
-                }
+                "default",
+                (o, n) => o.Default = n.CreateAny()
             },
             {
-                "discriminator", (o, n) =>
-                {
-                    o.Discriminator = LoadDiscriminator(n);
-                }
+                "nullable",
+                (o, n) => o.Nullable = bool.Parse(n.GetScalarValue())
             },
             {
-                "readOnly", (o, n) =>
-                {
-                    o.ReadOnly = bool.Parse(n.GetScalarValue());
-                }
+                "discriminator",
+                (o, n) => o.Discriminator = LoadDiscriminator(n)
             },
             {
-                "writeOnly", (o, n) =>
-                {
-                    o.WriteOnly = bool.Parse(n.GetScalarValue());
-                }
+                "readOnly",
+                (o, n) => o.ReadOnly = bool.Parse(n.GetScalarValue())
             },
             {
-                "xml", (o, n) =>
-                {
-                    o.Xml = LoadXml(n);
-                }
+                "writeOnly",
+                (o, n) => o.WriteOnly = bool.Parse(n.GetScalarValue())
             },
             {
-                "externalDocs", (o, n) =>
-                {
-                    o.ExternalDocs = LoadExternalDocs(n);
-                }
+                "xml",
+                (o, n) => o.Xml = LoadXml(n)
             },
             {
-                "example", (o, n) =>
-                {
-                    o.Example = n.CreateAny();
-                }
+                "externalDocs",
+                (o, n) => o.ExternalDocs = LoadExternalDocs(n)
             },
             {
-                "deprecated", (o, n) =>
-                {
-                    o.Deprecated = bool.Parse(n.GetScalarValue());
-                }
+                "example",
+                (o, n) => o.Example = n.CreateAny()
+            },
+            {
+                "deprecated",
+                (o, n) => o.Deprecated = bool.Parse(n.GetScalarValue())
             },
         };
 
-        private static readonly PatternFieldMap<OpenApiSchema> _schemaPatternFields = new PatternFieldMap<OpenApiSchema>
+        private static readonly PatternFieldMap<OpenApiSchema> _schemaPatternFields = new()
         {
             {s => s.StartsWith("x-"), (o, p, n) => o.AddExtension(p, LoadExtension(p,n))}
         };
 
-        private static readonly AnyFieldMap<OpenApiSchema> _schemaAnyFields = new AnyFieldMap<OpenApiSchema>
+        private static readonly AnyFieldMap<OpenApiSchema> _schemaAnyFields = new()
         {
             {
                 OpenApiConstants.Default,
-                new AnyFieldMapParameter<OpenApiSchema>(
+                new(
                     s => s.Default,
                     (s, v) => s.Default = v,
                     s => s)
             },
             {
                  OpenApiConstants.Example,
-                new AnyFieldMapParameter<OpenApiSchema>(
+                new(
                     s => s.Example,
                     (s, v) => s.Example = v,
                     s => s)
             }
         };
 
-        private static readonly AnyListFieldMap<OpenApiSchema> _schemaAnyListFields = new AnyListFieldMap<OpenApiSchema>
+        private static readonly AnyListFieldMap<OpenApiSchema> _schemaAnyListFields = new()
         {
             {
                 OpenApiConstants.Enum,
-                new AnyListFieldMapParameter<OpenApiSchema>(
+                new(
                     s => s.Enum,
                     (s, v) => s.Enum = v,
                     s => s)
@@ -280,7 +210,7 @@ namespace Microsoft.OpenApi.Readers.V3
 
             if (pointer != null)
             {
-                return new OpenApiSchema()
+                return new()
                 {
                     UnresolvedReference = true,
                     Reference = node.Context.VersionService.ConvertToOpenApiReference(pointer, ReferenceType.Schema)

--- a/test/Microsoft.OpenApi.Readers.Tests/ParseNodes/ParserHelperTests.cs
+++ b/test/Microsoft.OpenApi.Readers.Tests/ParseNodes/ParserHelperTests.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+using Microsoft.OpenApi.Readers.ParseNodes;
+using Xunit;
+
+namespace Microsoft.OpenApi.Readers.Tests.ParseNodes
+{
+    [Collection("DefaultSettings")]
+    public class ParserHelperTests
+    {
+        [Fact]
+        public void ParseDecimalWithFallbackOnOverflow_ReturnsParsedValue()
+        {
+            Assert.Equal(23434, ParserHelper.ParseDecimalWithFallbackOnOverflow("23434", 10));
+        }
+
+        [Fact]
+        public void ParseDecimalWithFallbackOnOverflow_Overflows_ReturnsFallback()
+        {
+            Assert.Equal(10, ParserHelper.ParseDecimalWithFallbackOnOverflow(double.MaxValue.ToString(), 10));
+        }
+    }
+}


### PR DESCRIPTION
If the customer tried to import an API which has a number type and maximum value set to value greater than the Decimal.Max (7.922816251426434E+28 for example) we do not return a validation error and instead we send a 500 error code and the Mapi code fails with exception:System.OverflowException.